### PR TITLE
forward: remove hosts entry feature

### DIFF
--- a/docs/source/forward-proxy.rst
+++ b/docs/source/forward-proxy.rst
@@ -170,13 +170,8 @@ For more information, see the `Caddy TLS configuration <https://caddyserver.com/
 Running the SCION HTTP Forward Proxy locally
 --------------------------------------------
 End users can run the SCION HTTP Forward Proxy locally by following the installation steps above.
-For smooth running experience, grant DAC capabilities to the binary:
 
-  .. code-block:: bash
-
-    sudo setcap cap_dac_override=+ep scion-caddy
-
-If you do not want to grant those privileges, you can run the binary without them but you will have to manually add the following line to your ``/etc/hosts`` before running the SCION HTTP Forward Proxy:
+Add the following line on ``/etc/hosts`` before running the SCION HTTP Forward Proxy:
 
   .. code-block:: bash
 

--- a/forward/forwardproxy.go
+++ b/forward/forwardproxy.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"net/textproto"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,7 +40,6 @@ import (
 )
 
 const (
-	hostsFile    = "/etc/hosts"
 	hostsComment = " # Line added by the SCION HTTP Forward Proxy"
 	hostName     = "forward-proxy.scion"
 	// TODO: make the address injectable via configuration
@@ -99,17 +97,11 @@ func (cp *CoreProxy) Initialize() error {
 	cp.metricsHandler = panpolicy.NewMetricsHandler(cp.policyManager, cp.logger.With(zap.String("component", "metrics-handler")))
 	cp.resolver = resolver.NewPANResolver(cp.logger.With(zap.String("component", "resolver")), cp.resolveTimeout)
 
-	if err := cp.addHostsEntry(); err != nil {
-		cp.logger.Warn("Failed to add entry to /etc/hosts file", zap.Error(err))
-	}
 	return nil
 }
 
 // Cleanup cleans up the core proxy logic.
 func (cp *CoreProxy) Cleanup() error {
-	if err := cp.removeHostsEntry(); err != nil {
-		cp.logger.Warn("Failed to remove entry from /etc/hosts file", zap.Error(err))
-	}
 	return cp.policyManager.Stop()
 }
 
@@ -172,58 +164,6 @@ func (cp *CoreProxy) HandleTunnelRequest(w http.ResponseWriter, r *http.Request)
 
 	cp.logger.Debug("Proxying.", zap.String("host", r.Host), zap.String("method", r.Method))
 	return cp.forwardRequest(w, r, dialer)
-}
-
-func (cp *CoreProxy) addHostsEntry() error {
-	content, err := os.ReadFile(hostsFile)
-	if err != nil {
-		return fmt.Errorf("failed to read hosts file: %w", err)
-	}
-
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		if !strings.HasPrefix(strings.TrimSpace(line), "#") && strings.Contains(line, hostName) {
-			cp.logger.Debug("Entry for host name already exists", zap.String("entry", line))
-			return nil
-		}
-	}
-
-	file, err := os.OpenFile(hostsFile, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open hosts file for writing: %w", err)
-	}
-	defer file.Close()
-
-	entry := hostsComment + "\n" + hostsEntry + "\n"
-	if _, err := file.WriteString(entry); err != nil {
-		return fmt.Errorf("failed to write to hosts file: %w", err)
-	}
-
-	cp.logger.Info("Added entry to hosts file", zap.String("entry", hostsEntry))
-	return nil
-}
-
-func (cp *CoreProxy) removeHostsEntry() error {
-	content, err := os.ReadFile(hostsFile)
-	if err != nil {
-		return fmt.Errorf("failed to read hosts file: %w", err)
-	}
-
-	var newLines []string
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		if !strings.Contains(line, hostsEntry) && !strings.Contains(line, hostsComment) {
-			newLines = append(newLines, line)
-		}
-	}
-
-	err = os.WriteFile(hostsFile, []byte(strings.Join(newLines, "\n")), 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write to hosts file: %w", err)
-	}
-
-	cp.logger.Info("Removed entry from hosts file", zap.String("entry", hostsEntry))
-	return nil
 }
 
 func (cp *CoreProxy) parseCookieFromProxyAuth(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
This PR remove the host entry feature and the associated documentation. This feature requires too high privileges and it is not worth it the security trade off for offloading the configuration. In case it is regarded as necessary a complementary more limited script can be added to modify the `etc/hosts` file.