### PR TITLE
network/singlestream: remove explicit version on listener side

### DIFF
--- a/networks/singlestream/network.go
+++ b/networks/singlestream/network.go
@@ -121,13 +121,8 @@ func (l *listenerSCION) listen(
 		NextProtos:   []string{quicutil.SingleStreamProto},
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 	}
-	quicConfig := &quic.Config{
-		Versions: []quic.Version{
-			quic.Version1,
-			quic.Version2,
-			0x5c10000f},
-	}
-	quicListener, err := listenQUIC(ctx, network, laddr, tlsCfg, quicConfig)
+
+	quicListener, err := listenQUIC(ctx, network, laddr, tlsCfg, nil)
 	if err != nil {
 		network.Logger().Error("failed to listen on QUIC", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
This PR removes the explicit QUIC versioning on the listener side which is not necessary since the Anapaya fork already overwrites this values on initialization: https://github.com/Anapaya/quic-go/commit/6f3edd0b821698375fb7a0781a1daccc3c724d11
